### PR TITLE
fix (log-parsing): Ignore errors when parsing /var/log/messages.

### DIFF
--- a/spencer.py
+++ b/spencer.py
@@ -364,7 +364,7 @@ def search_log_file(os_version):
         ERROR_PATTERN_NFS_MOUNT_ISSUE,
         ERROR_PATTERN_NFS_ACCESS_DENIED
     ]
-    with open('/var/log/messages', 'r') as file:
+    with open('/var/log/messages', 'r', errors='ignore') as file:
         for i, line in enumerate(file):
             line_lower = line.lower()  # Convert the line to lowercase for case-insensitive matching
             for pattern_tuple in error_patterns:


### PR DESCRIPTION
. On some systems python can fail to read file encoding correctly. Detects as ISO-8859-1 but fails to read as UTF-8

i.e. on one system I ran the script on this error would occur.  Adding the ignore allows the script to continue to parse the file and process the output.

```text
Traceback (most recent call last):
  File "/mnt/vol1/appdata/scripts/spencer.py", line 496, in <module>
    matches, match_counts, repeat_errors = search_log_file(os_version)
  File "/mnt/vol1/appdata/scripts/spencer.py", line 368, in search_log_file
    for i, line in enumerate(file):
  File "/usr/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd2 in position 3062: invalid continuation byte
```
